### PR TITLE
Implements IDateRangeIndex to exclude DateRecurringIndex by indexes with value in the keys of the catalog plan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,8 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/zope-product
 name: tests
 
 on:
   push:
   pull_request:
-  schedule:
-    - cron: '0 12 * * 0'  # run once a week on Sunday
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,60 @@
+# Generated from:
+# https://github.com/zopefoundation/meta/tree/master/config/zope-product
+name: tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 12 * * 0'  # run once a week on Sunday
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      # We want to see all failures:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu
+        config:
+        # [Python version, tox env]
+        - ["3.9",   "lint"]
+        - ["2.7",   "py27"]
+        - ["3.6",   "py36"]
+        - ["3.7",   "py37"]
+        - ["3.8",   "py38"]
+        - ["3.9",   "py39"]
+        - ["3.10",  "py310"]
+        - ["3.9",   "coverage"]
+
+    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.config[1] }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.config[0] }}
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Test
+      run: tox -e ${{ matrix.config[1] }}
+    - name: Coverage
+      if: matrix.config[1] == 'coverage'
+      run: |
+        pip install coveralls coverage-python-version
+        coveralls --service=github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 *.egg-info
 *.mo
 *.py?
-.*
 dist/
-!.gitattributes
-!.gitignore
+.coverage
+.coverage.*
+.eggs/
+.installed.cfg
+.mr.developer.cfg
+.tox/
+.vscode/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implements IDateRangeIndex so is excluded by index that could have value in the keys of the catalog plan
+  [mamico]
 
 
 3.0.1 (2019-10-03)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Implements IDateRangeIndex so is excluded by index that could have value in the keys of the catalog plan
+- Implements IDateRangeIndex to exclude DateRecurringIndex by indexes with value in the keys of the catalog plan
   [mamico]
 
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,7 @@
 include *.rst
+include buildout.cfg
+include tox.ini
+include buildout4.cfg
 recursive-include docs *
 recursive-include src *
 global-include *.mo

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,23 @@
+[buildout]
+extends =
+    https://zopefoundation.github.io/Zope/releases/master/versions.cfg
+develop = .
+parts =
+    interpreter
+    test
+
+[versions]
+Products.DateRecurringIndex =
+RestrictedPython = >= 5.1
+
+[interpreter]
+recipe = zc.recipe.egg
+interpreter = py
+eggs =
+    Products.DateRecurringIndex
+    tox
+
+[test]
+recipe = zc.recipe.testrunner
+eggs =
+    Products.DateRecurringIndex

--- a/buildout4.cfg
+++ b/buildout4.cfg
@@ -1,0 +1,7 @@
+[buildout]
+extends =
+    buildout.cfg
+    http://zopefoundation.github.io/Zope/releases/4.x/versions.cfg
+
+[versions]
+Products.DateRecurringIndex =

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 """Installer for the bda.aaf.site package."""
 
-from setuptools import find_packages
-from setuptools import setup
-
+from setuptools import find_packages, setup
 
 version = '3.0.2.dev0'
 short_description = "Zope 2 date index with support for recurring events."
@@ -31,6 +29,9 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     keywords='zope zope2 index catalog date recurring',
@@ -45,6 +46,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
+        'six',
         'BTrees',
         'plone.event',
         'Products.ZCatalog',

--- a/src/Products/DateRecurringIndex/testing.py
+++ b/src/Products/DateRecurringIndex/testing.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-from plone.testing import z2
-from plone.testing import Layer
+from plone.testing import Layer, z2
 
 
 class DRILayer(Layer):

--- a/src/Products/DateRecurringIndex/tests.py
+++ b/src/Products/DateRecurringIndex/tests.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
-import unittest
 import doctest
+import unittest
+from datetime import datetime
+
+import pytz
+from OFS.Folder import Folder
+from Products.ZCatalog.Catalog import Catalog
+from Products.ZCatalog.ZCatalog import ZCatalog
+from zope.testing import cleanup
+
+from Products.DateRecurringIndex.index import DateRecurringIndex
 
 optionflags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 
 
 class DummyEvent(object):
     """some dummy with a start, delta and until to index"""
+
     def __init__(self, id=None, start=None, recurdef=None, until=None):
         self.id = id
         self.start = start
@@ -15,161 +25,175 @@ class DummyEvent(object):
 
 
 class DummyExtras(object):
-    def __init__(self, recurrence_type=None,
-                 recurdef=None, until=None):
+    def __init__(self, recurrence_type=None, recurdef=None, until=None):
         self.recurrence_type = recurrence_type
         self.recurdef = recurdef
         self.until = until
 
 
-class TestIndex(unittest.TestCase):
+class TestIndex(cleanup.CleanUp, unittest.TestCase):
+    def setUp(self):
+        cleanup.CleanUp.setUp(self)
 
     def test_index(self):
-        """Test the index in icalendar/rfc5545 recurrence mode.
-        """
-
+        """Test the index in icalendar/rfc5545 recurrence mode."""
         # Initialize the catalog with DateRecurringIndex
-        from Products.DateRecurringIndex.index import DateRecurringIndex
-
         dri = DateRecurringIndex(
-            'start',
+            "start",
             extra=DummyExtras(
-                recurrence_type='ical',
-                recurdef='recurdef',
-                until='until')
+                recurrence_type="ical", recurdef="recurdef", until="until"
+            ),
         )
 
         # Index must have be the same name as dri's id
-        from Products.ZCatalog.Catalog import Catalog
-
         cat = Catalog()
-        cat.addIndex('start', dri)
-        cat.addColumn('id')
+        cat.addIndex("start", dri)
+        cat.addColumn("id")
 
         # catalog needs to be contained somewhere, otherwise
         # aquisition-wrapping of result brains doesn't work
-        from OFS.Folder import Folder
-        portal = Folder(id='portal')
+        portal = Folder(id="portal")
         cat.__parent__ = portal
 
         # Let's define some dummy events and catalog them.
-        from datetime import datetime
-        import pytz
-        cet = pytz.timezone('CET')
+        cet = pytz.timezone("CET")
 
         # Index the same event more than once and test if index size changes.
         test_event = DummyEvent(
-            id='test_event',
+            id="test_event",
             start=datetime(2001, 1, 1),
-            recurdef='RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5'
+            recurdef="RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5",
         )
-        self.assertEqual(
-            cat.catalogObject(test_event, 'test_event'),
-            1
-        )
+        self.assertEqual(cat.catalogObject(test_event, "test_event"), 1)
         self.assertEqual(dri.indexSize(), 5)
 
         test_event = DummyEvent(
-            id='test_event',
+            id="test_event",
             start=datetime(2001, 1, 1),
-            recurdef='RRULE:FREQ=DAILY;INTERVAL=1;COUNT=3'
+            recurdef="RRULE:FREQ=DAILY;INTERVAL=1;COUNT=3",
         )
-        self.assertEqual(
-            cat.catalogObject(test_event, 'test_event'),
-            1
-        )
+        self.assertEqual(cat.catalogObject(test_event, "test_event"), 1)
         self.assertEqual(dri.indexSize(), 3)
 
         test_event = DummyEvent(
-            id='test_event',
+            id="test_event",
             start=datetime(2001, 1, 1),
-            recurdef='RRULE:FREQ=DAILY;INTERVAL=1;COUNT=8'
+            recurdef="RRULE:FREQ=DAILY;INTERVAL=1;COUNT=8",
         )
-        self.assertEqual(
-            cat.catalogObject(test_event, 'test_event'),
-            1
-        )
+        self.assertEqual(cat.catalogObject(test_event, "test_event"), 1)
         self.assertEqual(dri.indexSize(), 8)
 
-        cat.uncatalogObject('test_event')
+        cat.uncatalogObject("test_event")
         self.assertEqual(dri.indexSize(), 0)
 
         # Index for querying later on...
         nonr = DummyEvent(
-            id='nonr', start=datetime(2010, 10, 10, 0, 0, tzinfo=cet)
-        )
+            id="nonr", start=datetime(2010, 10, 10, 0, 0, tzinfo=cet))
         days = DummyEvent(
-            id='days', start=datetime(2010, 10, 10, 0, 0, tzinfo=cet),
-            recurdef='RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5'
+            id="days",
+            start=datetime(2010, 10, 10, 0, 0, tzinfo=cet),
+            recurdef="RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5",
         )
         mins = DummyEvent(
-            id='mins', start=datetime(2010, 10, 10, 0, 0, tzinfo=cet),
-            recurdef='RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5'
+            id="mins",
+            start=datetime(2010, 10, 10, 0, 0, tzinfo=cet),
+            recurdef="RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5",
         )
         dstc = DummyEvent(
-            id='dstc', start=datetime(2010, 10, 20, 0, 0, tzinfo=cet),
-            recurdef='RRULE:FREQ=HOURLY;INTERVAL=1;COUNT=7'
+            id="dstc",
+            start=datetime(2010, 10, 20, 0, 0, tzinfo=cet),
+            recurdef="RRULE:FREQ=HOURLY;INTERVAL=1;COUNT=7",
         )
 
-        cat.catalogObject(nonr, 'nonr')
-        cat.catalogObject(days, 'days')
-        cat.catalogObject(mins, 'mins')
-        cat.catalogObject(dstc, 'dstc')
+        cat.catalogObject(nonr, "nonr")
+        cat.catalogObject(days, "days")
+        cat.catalogObject(mins, "mins")
+        cat.catalogObject(dstc, "dstc")
 
         # Query min one specific date
         query = {
-            'start': {
-                'query': datetime(2010, 10, 10, 0, 0, tzinfo=cet),
-                'range': 'min',
+            "start": {
+                "query": datetime(2010, 10, 10, 0, 0, tzinfo=cet),
+                "range": "min",
             },
         }
         res = cat(**query)
         self.assertEqual(
-            sorted([it.id for it in res]),
-            ['days', 'dstc', 'mins', 'nonr']
+            sorted([it.id for it in res]), ["days", "dstc", "mins", "nonr"]
         )
 
         # Query max one specific date
         query = {
-            'start': {
-                'query': datetime(2010, 10, 10, 0, 0, tzinfo=cet),
-                'range': 'max',
+            "start": {
+                "query": datetime(2010, 10, 10, 0, 0, tzinfo=cet),
+                "range": "max",
             },
         }
         res = cat(**query)
         self.assertEqual(
             sorted([it.id for it in res]),
-            ['days', 'mins', 'nonr']
+            ["days", "mins", "nonr"]
         )
 
         # Query timerange over days and dstc set
         query = {
-            'start': {
-                'query': [
+            "start": {
+                "query": [
                     datetime(2010, 10, 11, 0, 0, tzinfo=cet),
-                    datetime(2010, 11, 20, 0, 0, tzinfo=cet)
+                    datetime(2010, 11, 20, 0, 0, tzinfo=cet),
                 ],
-                'range': 'min:max',
+                "range": "min:max",
             },
         }
         res = cat(**query)
-        self.assertEqual(
-            sorted([brain.id for brain in res]),
-            ['days', 'dstc']
-        )
+        self.assertEqual(sorted([brain.id for brain in res]), ["days", "dstc"])
 
         # Query timerange over mins set
         query = {
-            'start': {
-                'query': [
+            "start": {
+                "query": [
                     datetime(2010, 10, 10, 0, 10, tzinfo=cet),
-                    datetime(2010, 10, 10, 0, 40, tzinfo=cet)
+                    datetime(2010, 10, 10, 0, 40, tzinfo=cet),
                 ],
-                'range': 'min:max',
+                "range": "min:max",
             },
         }
         res = cat(**query)
-        self.assertEqual(
-            sorted([brain.id for brain in res]),
-            ['mins']
+        self.assertEqual(sorted([brain.id for brain in res]), ["mins"])
+
+    def test_plan(self):
+        zcat = ZCatalog("catalog")
+        # Initialize the catalog with DateRecurringIndex
+        dri = DateRecurringIndex(
+            "start",
+            extra=DummyExtras(
+                recurrence_type="ical", recurdef="recurdef", until="until"
+            ),
+        )
+        # Index must have be the same name as dri's id
+        cat = zcat._catalog
+        cat.addIndex("start", dri)
+        cat.addColumn("id")
+        test_event = DummyEvent(
+            id="test_event",
+            start=datetime(2001, 1, 1),
+            recurdef="RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5",
+        )
+        cat.catalogObject(test_event, "test_event")
+        query = {
+            "start": {
+                "query": datetime(2010, 10, 10, 0, 0),
+                "range": "min",
+            },
+        }
+        zcat.search(query)
+        # Wrong benchmark key
+        self.assertNotIn(
+            "(('start', \"{'query': datetime.datetime(2010, 10, 10, 0, 0), 'range': 'min'}\"),): {",  # NOQA
+            zcat.getCatalogPlan(),
+        )
+        # Correct benchmark key
+        self.assertIn(
+            """('start',): {""",
+            zcat.getCatalogPlan(),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,88 @@
+# Generated from:
+# https://github.com/zopefoundation/meta/tree/master/config/zope-product
+[tox]
+minversion = 3.18
+envlist =
+    lint
+    py27
+    py36
+    py37
+    py38
+    py39
+    py310
+    coverage
+
+[testenv]
+skip_install = true
+deps =
+    zc.buildout >= 3.0.0rc3
+    wheel > 0.37
+commands_pre =
+    py27: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    !py27: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+commands =
+    {envbindir}/test {posargs:-cv}
+
+[testenv:lint]
+basepython = python3
+commands_pre =
+    mkdir -p {toxinidir}/parts/flake8
+allowlist_externals =
+    mkdir
+commands =
+    isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
+    - flake8 {toxinidir}/src {toxinidir}/setup.py
+    flake8 {toxinidir}/src {toxinidir}/setup.py
+    check-manifest
+    check-python-versions
+deps =
+    check-manifest
+    check-python-versions
+    flake8
+    isort
+    # Useful flake8 plugins that are Python and Plone specific:
+    flake8-coding
+    flake8-debugger
+    mccabe
+
+[testenv:isort-apply]
+basepython = python3
+commands_pre =
+deps =
+    isort
+commands =
+    isort {toxinidir}/src {toxinidir}/setup.py []
+
+[testenv:coverage]
+basepython = python3
+skip_install = true
+allowlist_externals =
+    mkdir
+deps =
+    {[testenv]deps}
+    coverage
+    coverage-python-version
+commands =
+    mkdir -p {toxinidir}/parts/htmlcov
+    coverage run {envbindir}/test {posargs:-cv}
+    coverage html
+    coverage report -m --fail-under=85
+
+[coverage:run]
+branch = True
+plugins = coverage_python_version
+source = Products.ZCatalog
+
+[coverage:report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    pragma: nocover
+    except ImportError:
+    raise NotImplementedError
+    if __name__ == '__main__':
+    self.fail
+    raise AssertionError
+
+[coverage:html]
+directory = parts/htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run {envbindir}/test {posargs:-cv}
     coverage html
-    coverage report -m --fail-under=85
+    coverage report -m --fail-under=80
 
 [coverage:run]
 branch = True

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 [coverage:run]
 branch = True
 plugins = coverage_python_version
-source = Products.ZCatalog
+source = Products.DateRecurringIndex
 
 [coverage:report]
 precision = 2


### PR DESCRIPTION
During analysis on ZCatalog plan (https://github.com/zopefoundation/Products.ZCatalog/pull/138), I saw many entries in the catalog plan with key as

`(('start', "{'query': datetime.datetime(2010, 10, 10, 0, 0), 'range': 'min'}"),)`

(where in my use case start is a `DateRecurringIndex`)

The fix proposal here avoids this behavior (change here: https://github.com/collective/Products.DateRecurringIndex/compare/mamico/catalogplan?expand=1#diff-2e7e66d717198090a3b8cd8c0152b953b7f12d782a0a46cc381776e6608be5ceR22)

In this PR there is also GitHub action to automate testing.

